### PR TITLE
replace the current Set to string call uses Array.from instead of spreading the Set object

### DIFF
--- a/src/$utils.js
+++ b/src/$utils.js
@@ -105,6 +105,6 @@ export function gen(input, options) {
 
 	close();
 
-	tmp = initials.size ? `{${ [...initials].join() }}=$$3,x` : ' x';
+	tmp = initials.size ? `{${ Array.from(initials).join() }}=$$3,x` : ' x';
 	return `var${tmp + txt}return x`;
 }


### PR DESCRIPTION
Following the issue #7 

This change uses a similar method to transform the `initials` to a string by using `Array.from` instead of spreading the Set object.

This works and solved my bug, is there any chance that you can get this into `master`? cc @lukeed 