### PR TITLE
fix: escape backticks found in user's input

### DIFF
--- a/src/$index.js
+++ b/src/$index.js
@@ -19,7 +19,7 @@ export function esc(value) {
 
 export function compile(input, options={}) {
 	return new (options.async ? (async()=>{}).constructor : Function)(
-		'$$1', '$$2', '$$3', gen(input, options)
+		'$$1', '$$2', '$$3', gen(input.replace(/`/g, '\\`'), options)
 	).bind(0, options.escape || esc, options.blocks);
 }
 

--- a/test/$index.js
+++ b/test/$index.js
@@ -253,6 +253,15 @@ compile('should allow `Compiler` output as blocks', () => {
 	);
 });
 
+compile('should render backticks without need of escaping', () => {
+	let output = tempura.compile('{{#expect value}}`{{value}}`');
+
+	assert.is(
+		output({ value: 'VALUE' }),
+		'`VALUE`'
+	);
+});
+
 compile.run();
 
 // ---


### PR DESCRIPTION
This PR escapes backticks of the input on behalf of users, and it enables us to write verbatim backticks in a template.

Fix #11.