### PR TITLE
Update escape feature in $index.js

### DIFF
--- a/src/$index.js
+++ b/src/$index.js
@@ -1,7 +1,9 @@
-const ESCAPE = /[&"<]/g, CHARS = {
+const ESCAPE = /[&"'<>]/g, CHARS = {
+	"'": '&apos;',
 	'"': '&quot;',
 	'&': '&amp;',
-	'<': '&lt',
+	'<': '&lt;',
+	'>': '&gt;'
 };
 
 import { gen } from './$utils';


### PR DESCRIPTION
- 🐛 add missing semicolon to `&lt` in `CHARS` (this was causing render to fail for me)
- ✨ add `>` = `&gt;` and `'` = `&apos;` (it just felt more... symmetrical)

Thanks!