### PR TITLE
refactor: faster html escape

### DIFF
--- a/src/$index.js
+++ b/src/$index.js
@@ -8,12 +8,12 @@ export function esc(value) {
 	for (; idx < len; idx++) {
 		char = value.charCodeAt(idx);
 
+		// <  60
 		// &  38
 		// "  34
 		// '  39
-		// <  60
 
-		if (char === 38 || char === 34 || char === 39 || char === 60) {
+		if (char === 60 || char === 38 || char === 34 || char === 39) {
 			out += value.substring(last, idx) + ('&#' + char + ';');
 			last = char + 1;
 		}

--- a/src/$index.js
+++ b/src/$index.js
@@ -1,19 +1,24 @@
-const ESCAPE = /[&"<]/g, CHARS = {
-	'"': '&quot;',
-	'&': '&amp;',
-	'<': '&lt',
-};
-
 import { gen } from './$utils';
 
 export function esc(value) {
 	value = (value == null) ? '' : '' + value;
-	let last=ESCAPE.lastIndex=0, tmp=0, out='';
-	while (ESCAPE.test(value)) {
-		tmp = ESCAPE.lastIndex - 1;
-		out += value.substring(last, tmp) + CHARS[value[tmp]];
-		last = tmp + 1;
+
+	let idx = 0, len = value.length, char = 0, last = 0, out = '';
+
+	for (; idx < len; idx++) {
+		char = value.charCodeAt(idx);
+
+		// &  38
+		// "  34
+		// '  39
+		// <  60
+
+		if (char === 38 || char === 34 || char === 39 || char === 60) {
+			out += value.substring(last, idx) + ('&#' + char + ';');
+			last = char + 1;
+		}
 	}
+
 	return out + value.substring(last);
 }
 


### PR DESCRIPTION
Removing the need for regex yields a ~240ops/sec increase.

Before:
```
  pug                x 2,121 ops/sec ±1.50% (91 runs sampled)
  handlebars         x 674 ops/sec ±1.39% (91 runs sampled)
  ejs                x 327 ops/sec ±1.57% (87 runs sampled)
  yeahjs             x 884 ops/sec ±1.30% (91 runs sampled)
  dot                x 608 ops/sec ±2.21% (91 runs sampled)
  art-template       x 2,085 ops/sec ±0.85% (93 runs sampled)
  tempura            x 2,186 ops/sec ±1.64% (93 runs sampled)
```
After:
```
  pug                x 2,010 ops/sec ±2.03% (89 runs sampled)
  handlebars         x 674 ops/sec ±1.30% (91 runs sampled)
  ejs                x 319 ops/sec ±1.61% (89 runs sampled)
  yeahjs             x 883 ops/sec ±1.19% (92 runs sampled)
  dot                x 617 ops/sec ±1.59% (91 runs sampled)
  art-template       x 2,070 ops/sec ±1.10% (93 runs sampled)
  tempura            x 2,426 ops/sec ±1.65% (92 runs sampled)
```