### PR TITLE
fix: resolve typescript declaration path for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,18 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./index.d.ts"
     },
     "./esbuild": {
       "import": "./esbuild/index.mjs",
-      "require": "./esbuild/index.js"
+      "require": "./esbuild/index.js",
+      "types": "./esbuild/index.d.ts"
     },
     "./rollup": {
       "import": "./rollup/index.mjs",
-      "require": "./rollup/index.js"
+      "require": "./rollup/index.js",
+      "types": "./rollup/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./index.d.ts"
+      "require": "./dist/index.js"
     },
     "./esbuild": {
+      "types": "./esbuild/index.d.ts",
       "import": "./esbuild/index.mjs",
-      "require": "./esbuild/index.js",
-      "types": "./esbuild/index.d.ts"
+      "require": "./esbuild/index.js"
     },
     "./rollup": {
+      "types": "./rollup/index.d.ts",
       "import": "./rollup/index.mjs",
-      "require": "./rollup/index.js",
-      "types": "./rollup/index.d.ts"
+      "require": "./rollup/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This is a fix for people encountering this error during `tsc`:

```
***.ts:2:25 - error TS7016: Could not find a declaration file for module 'tempura'. '/***/node_modules/tempura/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/***/node_modules/tempura/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'tempura' library may need to update its package.json or typings.

2 import { compile } from "tempura";
                          ~~~~~~~~~
```