### PR TITLE
docs: add integration with Webpack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,11 @@ Benchmark: Render w/ escaped values
   tempura            x 2,922 ops/sec ±0.31% (96 runs sampled)
 ```
 
+## Integration with Webpack
+
+The [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin) can render various templating engines, [including Tempure](https://github.com/webdiscus/html-bundler-webpack-plugin#using-the-tempure).\
+Open [the usage example](https://stackblitz.com/edit/webpack-tempura?file=webpack.config.js) directly in a browser.
+
 ## License
 
 MIT © [Luke Edwards](https://lukeed.com)


### PR DESCRIPTION
Hello @lukeed,

thank you for really fastest template engine!

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin).
I added Tempura support to the plugin. I implemented the "build-in" `include` helper to use partials, e.g.:

```hbs
{{#include src='header.hbs' }}
```
where `src` is the attribute for path to a partial relative to the `views` plugin option, see below.

It is very easy to render Tempura templates with Webpack, for example here the Webpack config:

```js
const path = require('path');
const HtmlBundlerPlugin = require('html-bundler-webpack-plugin');

module.exports = {
  output: {
    path: path.resolve(__dirname, 'dist'),
    clean: true,
  },
  plugins: [
    new HtmlBundlerPlugin({
      entry: {
        index:  'src/views/pages/home.hbs', // => dist/index.html
        'about/index':  'src/views/pages/about.hbs', // => dist/about/index.html
      },
      preprocessor: 'tempura', // use the `tempura` template engine
      preprocessorOptions: {
        views: ['src/views/partials'], // find including partials in these directories
        blocks: {
          // define custom helpers here
          bar: ({ value }) => `<bar>${value}</bar>`,
        },
      },
    }),
  ],
};
```

You can try [the usage example](https://stackblitz.com/edit/webpack-tempura?file=webpack.config.js) directly in a browser.

# P.S.
The plugin's README already contains documentation on [How to use the Tempura template with Webpack](https://github.com/webdiscus/html-bundler-webpack-plugin?tab=readme-ov-file#using-the-tempura).
It would be great if you added information to your README about  _"Integration with Webpack"_.
